### PR TITLE
chore: Add space to fix list formatting in MkDocs

### DIFF
--- a/docs/ml_platform.md
+++ b/docs/ml_platform.md
@@ -12,7 +12,8 @@ A user can request 0 to 7 GPU instances as a resource for the notebook. A user c
 
 ## Selecting a Docker image
 
-Users can choose from five images: 
+Users can choose from five images:
+
 * ml_platform:latest -  has most of the ML packages (Tensorflow, Keras, ScikitLearn,...) preinstalled, and a small tutorial with example codes in /ML_platform_tests/tutorial, it supports NVidia GPUs and has ROOT preinstalled.
 * ml_platform:conda - comes with full anaconda.
 * ml_platform:julia - with Julia programming languge

--- a/docs/ml_platform.md
+++ b/docs/ml_platform.md
@@ -14,10 +14,10 @@ A user can request 0 to 7 GPU instances as a resource for the notebook. A user c
 
 Users can choose from five images:
 
-* ml_platform:latest -  has most of the ML packages (Tensorflow, Keras, ScikitLearn,...) preinstalled, and a small tutorial with example codes in /ML_platform_tests/tutorial, it supports NVidia GPUs and has ROOT preinstalled.
-* ml_platform:conda - comes with full anaconda.
-* ml_platform:julia - with Julia programming languge
-* ml_platform:lava - with Intel Lava neuromorphic computing framework
-* ml_platform:centos7-experimental
+* `ml_platform:latest` -  has most of the ML packages (Tensorflow, Keras, ScikitLearn,...) preinstalled, and a small tutorial with example codes in /ML_platform_tests/tutorial, it supports NVidia GPUs and has ROOT preinstalled.
+* `ml_platform:conda` - comes with full anaconda.
+* `ml_platform:julia` - with Julia programming languge
+* `ml_platform:lava` - with Intel Lava neuromorphic computing framework
+* `ml_platform:centos7-experimental`
 
 For software additions and upgrades please contact ivukotic@uchicago.edu.


### PR DESCRIPTION
The current render of https://maniaclab.uchicago.edu/af-docs/ml_platform/#selecting-a-docker-image is

![current-render](https://user-images.githubusercontent.com/5142394/216195405-4b099c66-1732-4fd7-b014-640ccbd062d9.png)

where there is a small render bug because MkDocs wants there to be a space before the list starts.

This PR addresses that and results in the following render

![new-render](https://user-images.githubusercontent.com/5142394/216195708-e0d1204a-a4b2-43ce-978c-31cdd61e6993.png)


The second commit that adds the `code` style backticks is stylistic, and if undesirable I'm happy to drop it.